### PR TITLE
fix: do not strip "v" from tag name

### DIFF
--- a/src/release.ts
+++ b/src/release.ts
@@ -172,7 +172,7 @@ function renderTemplate(
 
 function getReleaseTagName(): string {
   if (github.context.ref.startsWith('refs/tags/v')) {
-    return github.context.ref.replace('refs/tags/v', '')
+    return github.context.ref.replace('refs/tags/', '')
   }
 
   if (github.context.ref === 'refs/heads/main') {


### PR DESCRIPTION
stripping the "v" from the tag is performed via `getVersion` ([line 195](https://github.com/rajatjindal/spin-plugin-releaser/blob/bec1954691ed5e3fee661f8fbf0d520bf15b9fec/src/release.ts#L195)). The full tag name is required for the tag name lookup on [line 57](https://github.com/rajatjindal/spin-plugin-releaser/blob/bec1954691ed5e3fee661f8fbf0d520bf15b9fec/src/release.ts#L57) to succeed.

closes #18