### PR TITLE
Use alternate deployment and upload plugin json always

### DIFF
--- a/.github/workflows/pr-check-dist.yml
+++ b/.github/workflows/pr-check-dist.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.1.0
       
       - name: npm install
         run: npm install

--- a/dist/index.js
+++ b/dist/index.js
@@ -23299,7 +23299,10 @@ const tc = __importStar(__nccwpck_require__(7784));
 const buffer_1 = __nccwpck_require__(4300);
 const rest_1 = __nccwpck_require__(5375);
 const toml_1 = __importDefault(__nccwpck_require__(4920));
-const RELEASE_BOT_WEBHOOK_URL = 'https://spin-plugin-releaser.fermyon.app';
+// until https://github.com/fermyon/spin/issues/2905 can be fixed/deployed
+// on Fermyon cloud, use the deployment on my personal k8s cluster.
+// const RELEASE_BOT_WEBHOOK_URL = 'https://spin-plugin-releaser.fermyon.app'
+const RELEASE_BOT_WEBHOOK_URL = 'https://spinpluginreleasebot.rajatjindal.com';
 const DEFAULT_INDENT = '6';
 const token = core.getInput('github_token');
 const octokit = (() => {
@@ -23376,16 +23379,16 @@ function run() {
                     data: checksums.join('\n')
                 });
             }
+            core.info('uploading plugin json file as an asset to release');
+            yield octokit.rest.repos.uploadReleaseAsset({
+                owner: github.context.repo.owner,
+                repo: github.context.repo.repo,
+                release_id: release.id,
+                name: `${manifest.name}.json`,
+                data: rendered
+            });
+            core.info(`added ${manifest.name}.json file to release ${tagName}`);
             if (tagName === 'canary') {
-                core.info('uploading asset to canary release');
-                yield octokit.rest.repos.uploadReleaseAsset({
-                    owner: github.context.repo.owner,
-                    repo: github.context.repo.repo,
-                    release_id: release.id,
-                    name: `${manifest.name}.json`,
-                    data: rendered
-                });
-                core.info(`added ${manifest.name}.json file to release ${tagName}`);
                 return;
             }
             const rawBody = JSON.stringify(releaseReq);

--- a/src/release.ts
+++ b/src/release.ts
@@ -9,7 +9,10 @@ import {Buffer} from 'buffer'
 import {Octokit} from '@octokit/rest'
 import toml from 'toml'
 
-const RELEASE_BOT_WEBHOOK_URL = 'https://spin-plugin-releaser.fermyon.app'
+// until https://github.com/fermyon/spin/issues/2905 can be fixed/deployed
+// on Fermyon cloud, use the deployment on my personal k8s cluster.
+// const RELEASE_BOT_WEBHOOK_URL = 'https://spin-plugin-releaser.fermyon.app'
+const RELEASE_BOT_WEBHOOK_URL = 'https://spinpluginreleasebot.rajatjindal.com'
 
 interface MustacheView {
   TagName: string

--- a/src/release.ts
+++ b/src/release.ts
@@ -139,17 +139,17 @@ async function run(): Promise<void> {
       })
     }
 
-    if (tagName === 'canary') {
-      core.info('uploading asset to canary release')
-      await octokit.rest.repos.uploadReleaseAsset({
-        owner: github.context.repo.owner,
-        repo: github.context.repo.repo,
-        release_id: release.id,
-        name: `${manifest.name}.json`,
-        data: rendered
-      })
+    core.info('uploading plugin json file as an asset to release')
+    await octokit.rest.repos.uploadReleaseAsset({
+      owner: github.context.repo.owner,
+      repo: github.context.repo.repo,
+      release_id: release.id,
+      name: `${manifest.name}.json`,
+      data: rendered
+    })
 
-      core.info(`added ${manifest.name}.json file to release ${tagName}`)
+    core.info(`added ${manifest.name}.json file to release ${tagName}`)
+    if (tagName === 'canary') {
       return
     }
 


### PR DESCRIPTION
This makes two changes:

- Upload plugin json file as release asset irrespective of if release is canary or tagged
- Use an alternate deployment of bot which makes use of fix deployed proposed in https://github.com/fermyon/spin/pull/2906