### PR TITLE
add token header only for GitHub url

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -43274,7 +43274,9 @@ function safeEscape(text) {
 exports.safeEscape = safeEscape;
 function calculateSHA(url, token) {
     return __awaiter(this, void 0, void 0, function* () {
-        const downloadPath = yield tc.downloadTool(url, undefined, token ? `token ${token}` : undefined, {
+        const downloadPath = yield tc.downloadTool(url, undefined, url.startsWith('https://github.com/') && token
+            ? `token ${token}`
+            : undefined, {
             accept: 'application/octet-stream'
         });
         const buffer = (0, mockables_1.readFileSync)(downloadPath);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -77,7 +77,9 @@ export async function calculateSHA(
   const downloadPath = await tc.downloadTool(
     url,
     undefined,
-    token ? `token ${token}` : undefined,
+    url.startsWith('https://github.com/') && token
+      ? `token ${token}`
+      : undefined,
     {
       accept: 'application/octet-stream'
     }


### PR DESCRIPTION
fixes the issue where the releaser is adding token even for non-GitHub urls. 